### PR TITLE
Update exploitable results

### DIFF
--- a/arch/catalogue/README.md
+++ b/arch/catalogue/README.md
@@ -47,8 +47,6 @@ line reconfiguration, staff productivity.
 * [Competence Matchmaking Tool][cmt]. SUPSI's service to suggest
   personalised staff training in order to increase staff productivity
   and, consequently, production line efficiency.
-* Gate's AI-Learn?
-* Gate's Techimetro?
 * [Fatigue Monitoring System][fams]. Service for predicting the perceived fatigue exertion of workers. Developed by SUPSI.
 * SME-Oriented Platform Configurator. Developed by SUPSI.
 * [Intervention Manager][im]. Service to define

--- a/arch/catalogue/README.md
+++ b/arch/catalogue/README.md
@@ -8,6 +8,10 @@ it does, its purpose in the platform and role in the architecture
 as well as why it's valuable. Please use [this template][template]
 to add a new component to the list.
 
+Also, we've started working on a [platform exploitation doc][plat-er],
+but this is still early-day kind of stuff since we haven't fleshed
+out key aspects like business model, strategy, etc.
+
 
 ### Application services
 
@@ -88,6 +92,7 @@ intervention rules for orchestrating a production system. Developed by SUPSI.
 [fw]: ./fiware.md
 [im]: ./im.md
 [mpms]: ./mpms.md
+[plat-er]: ./platform-er.md
 [ppro]: ./prodpro.md
 [ql]: ./quantumleap.md
 [ramp]: ./marketplace.md

--- a/arch/catalogue/platform-er.md
+++ b/arch/catalogue/platform-er.md
@@ -1,0 +1,64 @@
+KITT4SME Platform Exploitation
+------------------------------
+> ...still a work in progress!
+
+
+### Description
+
+The KITT4SME platform is a distributed software system designed to
+deliver affordable, tailor-made AI at scale to European manufacturing
+SMEs.
+
+The platform features a 5-step workflow through which manufacturers
+on a budget and no IT expertise can still benefit from AI. The workflow
+begins with a "Diagnose" step where a company profile is elicited to
+determine business needs and opportunities for improvement. Using this
+information, in the "Compose" step, a company-specific, optimal subset
+of services is selected from the service marketplace. This tailor-made
+service kit is then assembled and deployed to acquire information from
+the manufacturer's shop floor. The kit processes that information to
+determine whether the shop floor is en route for a desirable or undesirable
+outcome---e.g. detect and explain anomalies, visualise key performance
+indicators, etc. These activities comprise the "Sense" step. In the
+"Intervene" step, the kit suggests and negotiates corrective actions
+to steer the shop floor towards the desired production and staff well-being
+goals. Finally, in the "Evolve" step, the outcome is analysed to improve
+the Diagnose and Compose steps, and to propose personalised staff training.
+
+From a technical standpoint, the platform can be characterised as a
+service mesh, multi-tenant, cloud architecture to assemble AI components
+from a marketplace into a tailor-made service offering for a factory,
+connect them to the shop floor, and enable them to store and exchange
+data in an interoperable, secure, privacy-preserving and scalable way.
+
+Both the platform provider and AI developers benefit from this cloud
+architecture. Thanks to extensive pooling of computing resources and
+sharing of services among tenants, the platform provider can dramatically
+reduce operational costs which, in turn, results in lower service cost
+for manufacturing SMEs. AI developers leverage the platform compute
+infrastructure so they can focus on delivering business value rather
+than building infrastructure.
+
+
+### Innovation
+
+TODO
+
+
+### Target customers
+
+* European manufacturers
+* AI developers developing solutions for the European manufacturing
+  industry
+* Cloud platform providers
+
+
+### Value proposition
+
+TODO
+
+
+### Progress
+
+MVP released, working towards pilot deployments. Some additional
+infrastructure required to support open calls.

--- a/arch/catalogue/platform-er.md
+++ b/arch/catalogue/platform-er.md
@@ -39,18 +39,25 @@ for manufacturing SMEs. AI developers leverage the platform compute
 infrastructure so they can focus on delivering business value rather
 than building infrastructure.
 
+![Technology stack context diagram.][tech-stack.dia]
+
 
 ### Innovation
 
 TODO
 
 
-### Target customers
+### Target market
 
 * European manufacturers
 * AI developers developing solutions for the European manufacturing
   industry
 * Cloud platform providers
+
+Early adopters
+
+* Manufacturing companies involved in the KITT4SME pilot deployments
+* Later on other manufacturers depending on market strategy
 
 
 ### Value proposition
@@ -62,3 +69,14 @@ TODO
 
 MVP released, working towards pilot deployments. Some additional
 infrastructure required to support open calls.
+
+Technology readiness level:
+
+* Initial: 3 (experimental proof of concept)
+* Current: 4 (technology validated in lab)
+* Expected: 7 (system prototype demonstration in operational environment)
+
+
+
+
+[tech-stack.dia]: https://raw.githubusercontent.com/c0c0n3/kitt4sme.live/main/docs/tech-stack.svg


### PR DESCRIPTION
This PR updates the software catalogue.

* Zap Technimetro and AI-Learn from the catalogue since we decided we're not going to list them as exploitable results anymore.
* Stash away some info about platform exploitation. Keep in mind this is still early-day kind of stuff since we haven't fleshed
out key aspects like business model, strategy, etc.